### PR TITLE
Supports getting envelope's sender view url

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -854,6 +854,29 @@ module DocusignRest
       JSON.parse(response.body)
     end
 
+    # Public returns the URL for embedded sending
+    #
+    # envelope_id - the ID of the envelope you wish to use
+    # return_url  - the URL you want the user to be directed to after he or she
+    #               closes the view
+    # headers     - optional hash of headers to merge into the existing
+    #               required headers for a multipart request.
+    #
+    # Returns the URL string for embedded sending
+    def get_sender_view(options = {})
+      content_type = { 'Content-Type' => 'application/json' }
+      content_type.merge(options[:headers]) if options[:headers]
+
+      uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:envelope_id]}/views/sender")
+
+      http = initialize_net_http_ssl(uri)
+
+      request = Net::HTTP::Post.new(uri.request_uri, headers(content_type))
+      request.body = { returnUrl: options[:return_url] }.to_json
+
+      response = http.request(request)
+      JSON.parse(response.body)
+    end
 
     # Public returns the URL for embedded console
     #

--- a/test/docusign_rest/client_test.rb
+++ b/test/docusign_rest/client_test.rb
@@ -272,6 +272,17 @@ describe DocusignRest::Client do
           response.must_be_kind_of(Net::HTTPSuccess)
         end
       end
+
+      it "should get envelope's sender view" do
+        VCR.use_cassette("get_envelope_sender_view") do
+          response = @client.get_sender_view(
+            envelope_id: @envelope_response["envelopeId"],
+          )
+
+          response['errorCode'].must_be_nil
+          response['url'].must_match(/http/)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Client support for [Post Sender View](https://www.docusign.com/p/RESTAPIGuide/RESTAPIGuide.htm#REST%20API%20References/Post%20Sender%20View.htm)
