### PR TITLE
Adds support to override reply-to address for envelope email

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -585,7 +585,7 @@ module DocusignRest
     # email/subject  - (Optional) short subject line for the email
     # email/body     - (Optional) custom text that will be injected into the
     #                  DocuSign generated email
-    # email/reply_to - Sets the Reply-To email used for the envelope
+    # email/reply_to - (Optional) Sets the Reply-To email used for the envelope
     # signers        - A hash of users who should receive the document and need
     #                  to sign it. More info about the options available for
     #                  this method are documented above it's method definition.

--- a/test/docusign_rest/client_test.rb
+++ b/test/docusign_rest/client_test.rb
@@ -87,7 +87,8 @@ describe DocusignRest::Client do
         response = @client.create_envelope_from_document(
           email: {
             subject: "test email subject",
-            body: "this is the email body and it's large!"
+            body: "this is the email body and it's large!",
+            reply_to: "no-reply@example.com"
           },
           # If embedded is set to true  in the signers array below, emails
           # don't go out and you can embed the signature page in an iFrame
@@ -194,7 +195,8 @@ describe DocusignRest::Client do
             status: 'sent',
             email: {
               subject: "The test email subject envelope",
-              body: "Envelope body content here"
+              body: "Envelope body content here",
+              reply_to: "no-reply@example.com"
             },
             template_id: @template_response["templateId"],
             signers: [


### PR DESCRIPTION
Implements support to send `emailSettings/replyEmailAddressOverride`.

See [REST API documentation](https://www.docusign.com/p/RESTAPIGuide/RESTAPIGuide.htm#REST%20API%20References/Send%20an%20Envelope%20from%20a%20Template.htm%3FTocPath%3DREST%2520API%2520References%7C_____39)